### PR TITLE
issue: Disable keepalive to prevent conn failed fprocess restart

### DIFF
--- a/executor/http_runner.go
+++ b/executor/http_runner.go
@@ -196,12 +196,12 @@ func makeProxyClient(dialTimeout time.Duration) *http.Client {
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
-				Timeout:   dialTimeout,
-				KeepAlive: 10 * time.Second,
+				Timeout: dialTimeout,
+				// KeepAlive: 10 * time.Second,  with server closed conn, upstream error due to not handle ECONNECERROR
 			}).DialContext,
 			MaxIdleConns:          100,
 			MaxIdleConnsPerHost:   100,
-			DisableKeepAlives:     false,
+			DisableKeepAlives:     true,
 			IdleConnTimeout:       500 * time.Millisecond,
 			ExpectContinueTimeout: 1500 * time.Millisecond,
 		},


### PR DESCRIPTION
for mode http, if fprocess is a web server with gunicorn and

set max requests for restarting worker, it might causes upstream failed

due to reused goroutine didn't handle ECONNECTION_REFUSE or reset by

peer.

Here the solution is to disable keepalive to not to reuse conn.

Resolved: i3840

